### PR TITLE
Disable ESLint Prop Types

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,8 @@ export default [
 		"rules": {
 			"react/react-in-jsx-scope": "off",
 			"react/jsx-uses-react": "off",
-			"indent": ["error", "tab"]
+			"indent": ["error", "tab"],
+			"react/prop-types": "off"
 		}
 	}
 ];


### PR DESCRIPTION
Disabled ESLint React Prop Types to supress prop validation warning

*This rule is used for runtime type-checking in JavaScript, though as we are working in TypeScript type-checking is done at compile-time using interfaces and types so the rule is made redundant*