### PR TITLE
Feat: Implement tech stack for Work page

### DIFF
--- a/src/components/pages/Work.tsx
+++ b/src/components/pages/Work.tsx
@@ -22,6 +22,13 @@ const Work: React.FC<WorkProps> = ({ displayCount }) => {
 						<Subhead sx={{ paddingBottom: "0.5rem" }}>{data.start} - {data.isCurrent ? "Present" : data.end}</Subhead>
 						<Text>{data.description}</Text>
 						{displayCount == null && (
+							<TagList disablePadding>
+								{data.technologies.map(tech => (
+									<TagListItem key={tech}>{tech}</TagListItem>
+								))}
+							</TagList>
+						)}
+						{displayCount == null && (
 							<List>
 								{data.responsibilities.map(responsibility => (
 									<ListItem disableGutters key={responsibility}>

--- a/src/components/pages/Work.tsx
+++ b/src/components/pages/Work.tsx
@@ -1,7 +1,6 @@
 import { work } from "../../data/work.data"
 import { Heading, Subhead, Text } from "../styled/StyledText"
-import { PageSection, ContentSection } from "../styled/StyledContainers"
-import { AnimatedContainer } from "../styled/StyledContainers"
+import { PageSection, ContentSection, AnimatedContainer, TagList, TagListItem } from "../styled/StyledContainers"
 import { List, ListItem } from "@mui/material"
 
 interface WorkProps {

--- a/src/components/styled/StyledContainers.ts
+++ b/src/components/styled/StyledContainers.ts
@@ -64,6 +64,7 @@ export const AnimatedContainer = styled(Box)(() => ({
 export const TagList = styled(List)(() => ({
 	display: "flex",
 	flexDirection: "row",
+	flexWrap: "wrap",
 	justifyContent: "start",
 	padding: "0.5rem 0"
 }))

--- a/src/data/work.data.ts
+++ b/src/data/work.data.ts
@@ -60,7 +60,7 @@ export const work: WorkHistory[] = [
 		end: "Sep 2025",
 		isCurrent: false,
 		description: "Resolved complex software issues within defined SLOs while developing internal tools, managing integrations, and collaborating with development teams to improve workflows, performance, and system reliability.",
-		technologies: ["C#", "ASP.NET", ".NET Framework", "JavaScript", "React", "SQL Server Management Studio", "PowerShell"],
+		technologies: ["C#", "ASP.NET", ".NET Framework", "JavaScript", "React", "PowerShell"],
 		responsibilities: [
 			"Developed internal tooling and support applications to streamline workflows and improve efficiency for service desk agents.",
 			"Investigated and resolved complex issues escalated by Tier 1 and Tier 2 agents within SLO targets.",


### PR DESCRIPTION
## Changes
- **StyledContainers.ts**
  - added `flexWrap: "wrap"` to the existing TagList so multi-item stacks wrap on narrow viewports
- **Work.tsx** 
  - merged the duplicate import
  - rendered technologies as a `TagList` after the description
  - set `displayCount == null` to hide from landing page but allow display on work page