### PR TITLE
Chore: Remove redundant 30s sleep

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,8 +67,6 @@ jobs:
       - name: Check site health
         shell: bash
         run: |
-          sleep 30
-
           URLS=(
             "https://chadrakdev.netlify.app/"
             "https://chadrak.dev/"


### PR DESCRIPTION
Netlify deployment waits and outputs deployed URLs so the post-deployment smoke test won't run until after that anyways, so no need to sleep waiting for it to finish deployment