### PR TITLE
FEAT: Add linting check on PRs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,10 +5,38 @@ on:
   push:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Type check
+        run: yarn tsc --noEmit
+
   build:
     name: Build
     runs-on: ubuntu-24.04 # Pin to LTS version (avoid latest to prevent unexpected issues)
+    needs: lint
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
 Add lint + type-check to PR Checks workflow

Adds a `lint` job (ESLint + `tsc --noEmit`) that runs before `build`, so bad code fails fast instead of burning build minutes. `build` and `test` now depend on it passing.

Also added a `concurrency` group to cancel stale runs on new pushes to the same branch/PR.

No actual behavior change to `build`/`test` steps themselves, this PR is more geared toward strengthening CI/CD.