### PR TITLE
FEAT: Uplift codebase following remediation suggestions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-24.04
-    needs: [ build, test ]
+    needs: [build, test]
 
     steps:
       - name: Download build artifacts

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,7 +3,7 @@ name: PR Checks
 on:
   pull_request:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+yarn.lock

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+	"semi": false,
+	"useTabs": true,
+	"trailingComma": "all",
+	"printWidth": 100
+}

--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
 # Developer Portfolio
+
 [![Deploy](https://github.com/chadrakdev/dev-portfolio/actions/workflows/deploy.yml/badge.svg)](https://github.com/chadrakdev/dev-portfolio/actions/workflows/deploy.yml)
 
 [View portfolio](https://chadrak.dev)
-
 
 A minimalist developer portfolio built with **React**, **TypeScript**, and **Material UI**, bundled with Vite. This project essentially serves as an online CV, showcasing work history, personal projects, and contact information.
 
 ## Technologies
 
-| Technology | Version |
-|---|---|
-| React | 19 |
-| React Router | 7 |
-| Material UI | 6 |
-| TypeScript | 5.7 |
-| Vite | 6 |
+| Technology   | Version |
+| ------------ | ------- |
+| React        | 19      |
+| React Router | 7       |
+| Material UI  | 6       |
+| TypeScript   | 5.7     |
+| Vite         | 6       |
 
 ## Deployments
+
 CI/CD is handled entirely through GitHub Actions — the **PR Checks** workflow runs a build on every pull request to validate changes before merge, and then the **Build, Test and Deploy** workflow builds and ships to **Netlify** automatically on every push to `main`.
 
 ## Misc
+
 Inspired by Mark Horn's portfolio built with Astro, [see here](https://markhorn.dev/).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,27 +1,45 @@
-import globals from "globals";
-import pluginJs from "@eslint/js";
-import tseslint from "typescript-eslint";
-import pluginReact from "eslint-plugin-react";
-
+import globals from "globals"
+import pluginJs from "@eslint/js"
+import tseslint from "typescript-eslint"
+import pluginReact from "eslint-plugin-react"
+import pluginReactHooks from "eslint-plugin-react-hooks"
+import eslintConfigPrettier from "eslint-config-prettier"
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
 	{
-		files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"]
+		ignores: ["dist"],
 	},
 	{
-		languageOptions: { globals: globals.browser }
+		files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"],
+	},
+	{
+		languageOptions: { globals: globals.browser },
 	},
 	pluginJs.configs.recommended,
 	...tseslint.configs.recommended,
 	pluginReact.configs.flat.recommended,
 	{
-		"rules": {
+		settings: {
+			react: { version: "detect" },
+		},
+	},
+	{
+		plugins: {
+			"react-hooks": pluginReactHooks,
+		},
+		rules: {
+			...pluginReactHooks.configs.recommended.rules,
+		},
+	},
+	{
+		rules: {
 			"react/react-in-jsx-scope": "off",
 			"react/jsx-uses-react": "off",
-			"indent": ["error", "tab"],
 			"react/prop-types": "off",
-			"quotes": ["error", "double"]
-		}
-	}
-];
+		},
+	},
+	// Must stay last: disables stylistic ESLint rules that conflict with Prettier,
+	// which now owns all formatting concerns (see .prettierrc).
+	eslintConfigPrettier,
+]

--- a/index.html
+++ b/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Portfolio | Chadrak H</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Portfolio | Chadrak H</title>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="/src/main.tsx"></script>
+	</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,41 +1,42 @@
 {
-  "name": "dev-portfolio",
-  "private": true,
-  "version": "0.0.0",
-  "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
-    "lint": "eslint .",
-    "preview": "vite preview"
-  },
-  "dependencies": {
-    "@emotion/react": "^11.14.0",
-    "@emotion/styled": "^11.14.0",
-    "@fontsource/roboto": "^5.1.0",
-    "@mui/icons-material": "^6.3.0",
-    "@mui/material": "^6.3.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-router-dom": "^7.1.1"
-  },
-  "devDependencies": {
-    "@eslint/js": "^9.17.0",
-    "@types/react": "^19.0.2",
-    "@types/react-dom": "^19.0.2",
-    "@typescript-eslint/eslint-plugin": "^8.18.2",
-    "@typescript-eslint/parser": "^8.18.2",
-    "@vitejs/plugin-react": "^4.3.4",
-    "eslint": "^9.17.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-prettier": "^5.2.1",
-    "eslint-plugin-react": "^7.37.3",
-    "eslint-plugin-react-hooks": "^5.1.0",
-    "eslint-plugin-react-refresh": "^0.4.16",
-    "globals": "^15.14.0",
-    "prettier": "^3.4.2",
-    "typescript": "~5.7.2",
-    "typescript-eslint": "^8.18.2",
-    "vite": "^6.0.6"
-  }
+	"name": "dev-portfolio",
+	"private": true,
+	"version": "0.0.0",
+	"type": "module",
+	"scripts": {
+		"dev": "vite",
+		"build": "tsc -b && vite build",
+		"lint": "eslint .",
+		"format": "prettier --write .",
+		"format:check": "prettier --check .",
+		"preview": "vite preview"
+	},
+	"dependencies": {
+		"@emotion/react": "^11.14.0",
+		"@emotion/styled": "^11.14.0",
+		"@fontsource/roboto": "^5.1.0",
+		"@mui/icons-material": "^6.3.0",
+		"@mui/material": "^6.3.0",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0",
+		"react-router-dom": "^7.1.1"
+	},
+	"devDependencies": {
+		"@eslint/js": "^9.17.0",
+		"@types/react": "^19.0.2",
+		"@types/react-dom": "^19.0.2",
+		"@typescript-eslint/eslint-plugin": "^8.18.2",
+		"@typescript-eslint/parser": "^8.18.2",
+		"@vitejs/plugin-react": "^4.3.4",
+		"eslint": "^9.17.0",
+		"eslint-config-prettier": "^9.1.0",
+		"eslint-plugin-react": "^7.37.3",
+		"eslint-plugin-react-hooks": "^5.1.0",
+		"eslint-plugin-react-refresh": "^0.4.16",
+		"globals": "^15.14.0",
+		"prettier": "^3.4.2",
+		"typescript": "~5.7.2",
+		"typescript-eslint": "^8.18.2",
+		"vite": "^6.0.6"
+	}
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,59 +11,77 @@ import Work from "./components/pages/Work"
 import Projects from "./components/pages/Projects"
 import Contact from "./components/pages/Contact"
 import Footer from "./components/footer/Footer"
+import { AnimatedContainer } from "./components/styled/StyledContainers"
 
-const App = () => {
-	const [isDarkMode, setIsDarkMode] = useState(true);
-
-	const toggleTheme = () => {
-		setIsDarkMode((prevMode) => !(prevMode))
-	}
-
-	const location = useLocation();
-
-	const parsePath = (pathname: string) => {
-		switch (pathname) {
-		case ("/"): {
+const parsePath = (pathname: string) => {
+	switch (pathname) {
+		case "/": {
 			return "Home"
 		}
-		case ("/work"): {
+		case "/work": {
 			return "Work"
 		}
-		case ("/projects"): {
+		case "/projects": {
 			return "Projects"
 		}
-		case ("/contact"): {
+		case "/contact": {
 			return "Contact"
 		}
 		default: {
 			return ""
 		}
-		}
+	}
+}
+
+const App = () => {
+	const [isDarkMode, setIsDarkMode] = useState(true)
+
+	const toggleTheme = () => {
+		setIsDarkMode((prevMode) => !prevMode)
 	}
 
-	const setDocumentTitle = () => {
+	const location = useLocation()
+
+	useEffect(() => {
 		const title = parsePath(location.pathname)
 
-		if (title.length > 1) {
-			document.title = `${parsePath(location.pathname)} | Chadrak H`
+		if (title) {
+			document.title = `${title} | Chadrak H`
 		}
-	}
-	
-	useEffect(() => {
-		setDocumentTitle();
 	}, [location.pathname])
 
 	return (
-		<ThemeProvider theme={isDarkMode? darkTheme : lightTheme}>
+		<ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
 			<CssBaseline />
 			<AppLayout>
 				<NavBar onToggleTheme={toggleTheme} isDarkMode={isDarkMode} />
 				<PageLayout>
 					<Routes>
 						<Route path="/" element={<Home />} />
-						<Route path="/work" element={<Work />} />
-						<Route path="/projects" element={<Projects />} />
-						<Route path="/contact" element={<Contact />} />
+						<Route
+							path="/work"
+							element={
+								<AnimatedContainer>
+									<Work />
+								</AnimatedContainer>
+							}
+						/>
+						<Route
+							path="/projects"
+							element={
+								<AnimatedContainer>
+									<Projects />
+								</AnimatedContainer>
+							}
+						/>
+						<Route
+							path="/contact"
+							element={
+								<AnimatedContainer>
+									<Contact />
+								</AnimatedContainer>
+							}
+						/>
 					</Routes>
 				</PageLayout>
 				<Footer />

--- a/src/components/content/ContentList.tsx
+++ b/src/components/content/ContentList.tsx
@@ -1,16 +1,8 @@
-import { ReactNode } from "react"
-import { ContentSection } from "../styled/StyledContainers";
+import { ContentSection } from "../styled/StyledContainers"
+import { WithChildren } from "../../types/common"
 
-interface ContentListProps {
-    children: ReactNode;
-}
-
-const ContentList: React.FC<ContentListProps> = ({ children }) => {
-	return (
-		<ContentSection>
-			{children}
-		</ContentSection>
-	)
+const ContentList = ({ children }: WithChildren) => {
+	return <ContentSection>{children}</ContentSection>
 }
 
 export default ContentList

--- a/src/components/content/ContentListItem.tsx
+++ b/src/components/content/ContentListItem.tsx
@@ -1,25 +1,17 @@
-import { ContentSection } from "../styled/StyledContainers";
-import { Heading, Text } from "../styled/StyledText";
-import { LinkWrapper } from "../styled/StyledLinks";
+import { ContentSection } from "../styled/StyledContainers"
+import { Heading, Text } from "../styled/StyledText"
+import { LinkWrapper } from "../styled/StyledLinks"
 
 interface ContentListItemProps {
-    title: string;
-    description: string;
-    url: string;
+	title: string
+	description: string
+	url: string
 }
 
-const ContentListItem: React.FC<ContentListItemProps> = ({ title, description, url }) => {
+const ContentListItem = ({ title, description, url }: ContentListItemProps) => {
 	return (
-		<ContentSection
-			hasBorder
-			hasMargin
-			hasPadding
-			enableHover
-		>
-			<LinkWrapper
-				target="_blank"
-				rel="noopener noreferrer"
-				to={url}>
+		<ContentSection hasBorder hasMargin hasPadding enableHover>
+			<LinkWrapper target="_blank" rel="noopener noreferrer" to={url}>
 				<Heading>{title}</Heading>
 				<Text>{description}</Text>
 			</LinkWrapper>

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -2,15 +2,13 @@ import { styled, Container } from "@mui/material"
 import { Text } from "../styled/StyledText"
 
 const StyledFooter = styled(Container)(() => ({
-	padding: "0"
+	padding: "0",
 }))
 
 const Footer = () => {
 	return (
 		<StyledFooter disableGutters>
-			<Text>
-                © 2026 | Chadrak Holondo
-			</Text>
+			<Text>© 2026 | Chadrak Holondo</Text>
 		</StyledFooter>
 	)
 }

--- a/src/components/layouts/AppLayout.tsx
+++ b/src/components/layouts/AppLayout.tsx
@@ -1,23 +1,11 @@
-import { styled, Container } from "@mui/material"
-import { ReactNode } from "react"
+import { AppContainer } from "../styled/StyledContainers"
+import { WithChildren } from "../../types/common"
 
-const StyledContainer = styled(Container)(({ theme }) => ({
-	maxWidth: "80%",
-	margin: "0 auto",
-	[theme.breakpoints.down("sm")]: {
-		maxWidth: "90%"
-	},
-}))
-
-interface LayoutProps {
-    children: ReactNode;
-}
-
-const AppLayout : React.FC<LayoutProps> = ({ children }) => {
+const AppLayout = ({ children }: WithChildren) => {
 	return (
-		<StyledContainer maxWidth="sm" disableGutters>
+		<AppContainer maxWidth="sm" disableGutters>
 			{children}
-		</StyledContainer>
+		</AppContainer>
 	)
 }
 

--- a/src/components/layouts/PageLayout.tsx
+++ b/src/components/layouts/PageLayout.tsx
@@ -1,21 +1,8 @@
-import { styled, Container } from "@mui/material"
-import { ReactNode } from "react"
+import { PageContainer } from "../styled/StyledContainers"
+import { WithChildren } from "../../types/common"
 
-const StyledContainer = styled(Container)(() => ({
-	padding: "3rem 0.1rem",
-	margin: "0",
-}))
-
-interface LayoutProps {
-    children: ReactNode;
-}
-
-const PageLayout : React.FC<LayoutProps> = ({ children }) => {
-	return (
-		<StyledContainer disableGutters>
-			{children}
-		</StyledContainer>
-	)
+const PageLayout = ({ children }: WithChildren) => {
+	return <PageContainer disableGutters>{children}</PageContainer>
 }
 
 export default PageLayout

--- a/src/components/navigation/NavBar.tsx
+++ b/src/components/navigation/NavBar.tsx
@@ -1,28 +1,39 @@
 import { IconButton } from "@mui/material"
-import { Code } from "@mui/icons-material";
-import { LightMode, DarkMode } from "../styled/StyledIcons";
-import { LinkIcon, LinkNavText } from "../styled/StyledLinks";
-import { NavContainer, ContentSection } from "../styled/StyledContainers";
+import { Code } from "@mui/icons-material"
+import { LightMode, DarkMode } from "../styled/StyledIcons"
+import { LinkIcon, LinkNavText } from "../styled/StyledLinks"
+import { NavContainer, ContentSection } from "../styled/StyledContainers"
 
 interface NavBarProps {
-	onToggleTheme: () => void;
-	isDarkMode: boolean;
+	onToggleTheme: () => void
+	isDarkMode: boolean
 }
 
-const NavBar: React.FC<NavBarProps> = ({ onToggleTheme, isDarkMode }) => {
+const NavBar = ({ onToggleTheme, isDarkMode }: NavBarProps) => {
 	return (
 		<NavContainer>
-			<LinkIcon hasPadding to="/"><Code /></LinkIcon>
+			<LinkIcon hasPadding to="/" aria-label="Home">
+				<Code />
+			</LinkIcon>
 			<ContentSection>
-				<LinkNavText hasPadding to="work">work</LinkNavText>
-				<LinkNavText hasPadding to="projects">projects</LinkNavText>
-				<LinkNavText hasPadding to="contact">contact</LinkNavText>
-				<IconButton onClick={onToggleTheme}>
+				<LinkNavText hasPadding to="work">
+					work
+				</LinkNavText>
+				<LinkNavText hasPadding to="projects">
+					projects
+				</LinkNavText>
+				<LinkNavText hasPadding to="contact">
+					contact
+				</LinkNavText>
+				<IconButton
+					onClick={onToggleTheme}
+					aria-label={isDarkMode ? "Switch to light mode" : "Switch to dark mode"}
+				>
 					{isDarkMode ? <DarkMode /> : <LightMode />}
 				</IconButton>
 			</ContentSection>
 		</NavContainer>
-	);
-};
+	)
+}
 
-export default NavBar;
+export default NavBar

--- a/src/components/pages/Contact.tsx
+++ b/src/components/pages/Contact.tsx
@@ -1,26 +1,26 @@
-import { AnimatedContainer, ContentSection } from "../styled/StyledContainers"
-import { PageSection } from "../styled/StyledContainers"
+import { ContentSection, PageSection } from "../styled/StyledContainers"
 import { Heading, Text } from "../styled/StyledText"
 import { LinkText, LinkIcon } from "../styled/StyledLinks"
 import { GitHub, LinkedIn } from "../styled/StyledIcons"
 
 const Contact = () => {
 	return (
-		<AnimatedContainer>
-			<PageSection key="contact">
-				<Heading hasPadding>Let&apos;s Connect</Heading>
-				<Text>Whether you have a question, a project idea, or just want to say hello, you can reach out via social media or drop me an email.</Text>
-				<ContentSection>
-					<LinkIcon hasPadding to="https://github.com/chadrakdev">
-						<GitHub />
-					</LinkIcon>
-					<LinkIcon hasPadding to="https://linkedin.com/in/chadrakholondo/">
-						<LinkedIn />
-					</LinkIcon>
-				</ContentSection>
-				<LinkText to="mailto:chadrakdev@outlook.com">chadrakdev@outlook.com</LinkText>
-			</PageSection>
-		</AnimatedContainer>
+		<PageSection key="contact">
+			<Heading hasPadding>Let&apos;s Connect</Heading>
+			<Text>
+				Whether you have a question, a project idea, or just want to say hello, you can reach out
+				via social media or drop me an email.
+			</Text>
+			<ContentSection>
+				<LinkIcon hasPadding to="https://github.com/chadrakdev" aria-label="GitHub">
+					<GitHub />
+				</LinkIcon>
+				<LinkIcon hasPadding to="https://linkedin.com/in/chadrakholondo/" aria-label="LinkedIn">
+					<LinkedIn />
+				</LinkIcon>
+			</ContentSection>
+			<LinkText to="mailto:chadrakdev@outlook.com">chadrakdev@outlook.com</LinkText>
+		</PageSection>
 	)
 }
 

--- a/src/components/pages/Home.tsx
+++ b/src/components/pages/Home.tsx
@@ -14,10 +14,22 @@ const Home = () => {
 					<Heading>Chadrak H</Heading>
 					<Heading hasPadding>Software Engineer</Heading>
 					<Text>
-						I&apos;m a full-stack developer working in software support, where I build internal tools and tackle complex technical issues. I have hands-on experience with C# and React, developing scalable applications — especially in financial services and real estate. I love problem-solving and always look for ways to improve my skills and build better solutions.
+						I&apos;m a full-stack developer working in software support, where I build internal
+						tools and tackle complex technical issues. I have hands-on experience with C# and React,
+						developing scalable applications — especially in financial services and real estate. I
+						love problem-solving and always look for ways to improve my skills and build better
+						solutions.
 					</Text>
 					<Text>
-						You can check out some of my latest projects <LinkText isBold to="/projects">here</LinkText>, and more on my <LinkText isBold to="https://github.com/chadrakdev">GitHub</LinkText>.
+						You can check out some of my latest projects{" "}
+						<LinkText isBold to="/projects">
+							here
+						</LinkText>
+						, and more on my{" "}
+						<LinkText isBold to="https://github.com/chadrakdev">
+							GitHub
+						</LinkText>
+						.
 					</Text>
 				</PageSection>
 				<Work displayCount={1} />

--- a/src/components/pages/Projects.tsx
+++ b/src/components/pages/Projects.tsx
@@ -1,34 +1,28 @@
 import { Heading } from "../styled/StyledText"
 import { projects } from "../../data/projects.data"
 import { PageSection } from "../styled/StyledContainers"
-import { AnimatedContainer } from "../styled/StyledContainers"
 import ContentList from "../content/ContentList"
 import ContentListItem from "../content/ContentListItem"
-import React from "react"
+import { DisplayCountProps } from "../../types/common"
 
-interface ProjectsProps {
-	displayCount?: number
-}
+const Projects = ({ displayCount }: DisplayCountProps) => {
+	const visibleProjects = displayCount == null ? projects : projects.slice(0, displayCount)
 
-const Projects: React.FC<ProjectsProps> = ({ displayCount = projects.length }) => {
 	return (
-		<AnimatedContainer>
-		  <PageSection>
-				<Heading hasPadding>Projects</Heading>
-				<ContentList>
-			  {projects.slice(0, displayCount).map((data) => (
-		
-				  <ContentListItem
-					  key={data.id}
-					  title={data.title}
-					  description={data.description}
-					  url={data.url}
-				  />
-			  ))}
-				</ContentList>
-		  </PageSection>
-		</AnimatedContainer>
-	  )
+		<PageSection>
+			<Heading hasPadding>Projects</Heading>
+			<ContentList>
+				{visibleProjects.map((data) => (
+					<ContentListItem
+						key={data.id}
+						title={data.title}
+						description={data.description}
+						url={data.url}
+					/>
+				))}
+			</ContentList>
+		</PageSection>
+	)
 }
 
 export default Projects

--- a/src/components/pages/Work.tsx
+++ b/src/components/pages/Work.tsx
@@ -1,46 +1,44 @@
 import { work } from "../../data/work.data"
 import { Heading, Subhead, Text } from "../styled/StyledText"
-import { PageSection, ContentSection, AnimatedContainer, TagList, TagListItem } from "../styled/StyledContainers"
+import { PageSection, ContentSection, TagList, TagListItem } from "../styled/StyledContainers"
 import { List, ListItem } from "@mui/material"
+import { DisplayCountProps } from "../../types/common"
 
-interface WorkProps {
-	displayCount?: number
-}
-
-const Work: React.FC<WorkProps> = ({ displayCount }) => {
+const Work = ({ displayCount }: DisplayCountProps) => {
+	const isPreview = displayCount != null
 	const workEntries = [...work].reverse()
-	const visibleWork = displayCount == null ? workEntries : workEntries.slice(0, displayCount)
+	const visibleWork = isPreview ? workEntries.slice(0, displayCount) : workEntries
 
 	return (
-		<AnimatedContainer>
-			<PageSection key="work">
-				<Heading hasPadding>Work</Heading>
-				{visibleWork.map(data => 
-					<ContentSection hasPaddingBottom key={data.id}>
-						<Heading>{data.position}</Heading>
-						<Subhead>{data.company}</Subhead>
-						<Subhead sx={{ paddingBottom: "0.5rem" }}>{data.start} - {data.isCurrent ? "Present" : data.end}</Subhead>
-						<Text>{data.description}</Text>
-						{displayCount == null && (
-							<TagList disablePadding>
-								{data.technologies.map(tech => (
-									<TagListItem key={tech}>{tech}</TagListItem>
-								))}
-							</TagList>
-						)}
-						{displayCount == null && (
-							<List>
-								{data.responsibilities.map(responsibility => (
-									<ListItem disableGutters key={responsibility}>
-                    					• {responsibility}
-									</ListItem>
-								))}
-							</List>
-						)}
-					</ContentSection>
-				)}
-			</PageSection>
-		</AnimatedContainer>
+		<PageSection key="work">
+			<Heading hasPadding>Work</Heading>
+			{visibleWork.map((data) => (
+				<ContentSection hasPaddingBottom key={data.id}>
+					<Heading>{data.position}</Heading>
+					<Subhead>{data.company}</Subhead>
+					<Subhead hasPaddingBottom>
+						{data.start} - {data.isCurrent ? "Present" : data.end}
+					</Subhead>
+					<Text>{data.description}</Text>
+					{!isPreview && (
+						<TagList disablePadding>
+							{data.technologies.map((tech) => (
+								<TagListItem key={tech}>{tech}</TagListItem>
+							))}
+						</TagList>
+					)}
+					{!isPreview && (
+						<List>
+							{data.responsibilities.map((responsibility) => (
+								<ListItem disableGutters key={responsibility}>
+									• {responsibility}
+								</ListItem>
+							))}
+						</List>
+					)}
+				</ContentSection>
+			))}
+		</PageSection>
 	)
 }
 

--- a/src/components/styled/Animations.ts
+++ b/src/components/styled/Animations.ts
@@ -1,4 +1,4 @@
-import { keyframes } from "@mui/material";
+import { keyframes } from "@mui/material"
 
 export const fadeInAnimation = keyframes`
     0% {
@@ -9,4 +9,4 @@ export const fadeInAnimation = keyframes`
         transform: translateY(0%);
         opacity: 1;
     }
-`;
+`

--- a/src/components/styled/StyledContainers.ts
+++ b/src/components/styled/StyledContainers.ts
@@ -1,11 +1,14 @@
-import { styled, AppBar, Box, Container, List, ListItem } from "@mui/material";
-import { fadeInAnimation } from "../styled/Animations";
+import { styled, AppBar, Box, Container, List, ListItem } from "@mui/material"
+import { fadeInAnimation } from "../styled/Animations"
+
+// Not mode-dependent, so it lives as a plain constant rather than a theme token.
+const CONTENT_BORDER_COLOR = "#35353b62"
 
 export const AppContainer = styled(Container)(({ theme }) => ({
 	maxWidth: "80%",
 	margin: "0 auto",
 	[theme.breakpoints.down("sm")]: {
-		maxWidth: "90%"
+		maxWidth: "90%",
 	},
 }))
 
@@ -20,7 +23,7 @@ export const NavContainer = styled(AppBar)(({ theme }) => ({
 	backdropFilter: "blur(0.1rem)",
 	boxShadow: "none",
 	top: "0",
-	position: "sticky"
+	position: "sticky",
 }))
 
 export const PageContainer = styled(Container)(() => ({
@@ -29,31 +32,34 @@ export const PageContainer = styled(Container)(() => ({
 }))
 
 export const PageSection = styled(Box)(() => ({
-	paddingBottom: "2rem"
+	paddingBottom: "2rem",
 }))
 
 export const ContentSection = styled(Box, {
-	shouldForwardProp: (prop) => !["hasPadding", "hasPaddingBottom", "hasMargin", "hasBorder", "enableHover"].includes(prop as string),
+	shouldForwardProp: (prop) =>
+		!["hasPadding", "hasPaddingBottom", "hasMargin", "hasBorder", "enableHover"].includes(
+			prop as string,
+		),
 })<{
-	hasPadding?: boolean;
-	hasPaddingBottom?: boolean;
-	hasMargin?: boolean;
-	hasBorder?: boolean;
-	enableHover?: boolean;
+	hasPadding?: boolean
+	hasPaddingBottom?: boolean
+	hasMargin?: boolean
+	hasBorder?: boolean
+	enableHover?: boolean
 }>(({ hasPadding, hasPaddingBottom, hasMargin, hasBorder, enableHover, theme }) => ({
 	padding: hasPadding ? "1rem" : "0",
 	marginLeft: hasPadding ? "-0.9rem" : 0,
-  	paddingBottom: hasPaddingBottom ? "2rem" : "0",
-  	borderBottom: hasBorder ? "1px solid #35353b62" : "none",
-  	marginBottom: hasMargin ? "1rem" : "0",
+	paddingBottom: hasPaddingBottom ? "2rem" : "0",
+	borderBottom: hasBorder ? `1px solid ${CONTENT_BORDER_COLOR}` : "none",
+	marginBottom: hasMargin ? "1rem" : "0",
 	borderRadius: "1rem 1rem 0 0",
 	transition: "background-color 0.3s",
-  	...(enableHover && {
+	...(enableHover && {
 		"&:hover": {
-			backgroundColor: theme.palette.mode === "dark" ? "#1d1d21" : "#d8d8db"
-	  },
-  	}),
-}));
+			backgroundColor: theme.palette.surfaceHover,
+		},
+	}),
+}))
 
 export const AnimatedContainer = styled(Box)(() => ({
 	animation: `${fadeInAnimation} 0.8s ease`,
@@ -66,7 +72,7 @@ export const TagList = styled(List)(() => ({
 	flexDirection: "row",
 	flexWrap: "wrap",
 	justifyContent: "start",
-	padding: "0.5rem 0"
+	padding: "0.5rem 0",
 }))
 
 export const TagListItem = styled(ListItem)(({ theme }) => ({
@@ -80,6 +86,6 @@ export const TagListItem = styled(ListItem)(({ theme }) => ({
 	width: "auto",
 	"&:hover": {
 		color: theme.palette.text.primary,
-		backgroundColor: theme.palette.text.secondary
-	}
+		backgroundColor: theme.palette.text.secondary,
+	},
 }))

--- a/src/components/styled/StyledIcons.ts
+++ b/src/components/styled/StyledIcons.ts
@@ -1,17 +1,16 @@
-import { styled } from "@mui/material";
-import { LightModeOutlined, DarkModeOutlined } from "@mui/icons-material";
-import GitHubIcon from "@mui/icons-material/GitHub";
-import LinkedInIcon from "@mui/icons-material/LinkedIn";
-import XIcon from "@mui/icons-material/X";
+import { styled } from "@mui/material"
+import { LightModeOutlined, DarkModeOutlined } from "@mui/icons-material"
+import GitHubIcon from "@mui/icons-material/GitHub"
+import LinkedInIcon from "@mui/icons-material/LinkedIn"
 
 export const LightMode = styled(LightModeOutlined)(({ theme }) => ({
 	color: theme.palette.text.primary,
-	fontSize: "18px"
+	fontSize: "18px",
 }))
 
 export const DarkMode = styled(DarkModeOutlined)(({ theme }) => ({
 	color: theme.palette.text.primary,
-	fontSize: "18px"
+	fontSize: "18px",
 }))
 
 export const GitHub = styled(GitHubIcon, {
@@ -21,8 +20,8 @@ export const GitHub = styled(GitHubIcon, {
 	fontSize: "1.5rem",
 	paddingRight: hasPadding ? "1rem" : 0,
 	"&:hover": {
-		color: theme.palette.mode === "dark" ? "#ffffff" : "#000000"
-	}
+		color: theme.palette.strongText,
+	},
 }))
 
 export const LinkedIn = styled(LinkedInIcon, {
@@ -32,17 +31,6 @@ export const LinkedIn = styled(LinkedInIcon, {
 	fontSize: "1.5rem",
 	paddingRight: hasPadding ? "1rem" : 0,
 	"&:hover": {
-		color: theme.palette.mode === "dark" ? "#ffffff" : "#000000"
-	}
-}))
-
-export const Twitter = styled(XIcon, {
-	shouldForwardProp: (prop) => prop !== "hasPadding",
-})<{ hasPadding?: boolean }>(({ hasPadding, theme }) => ({
-	color: theme.palette.text.primary,
-	fontSize: "1.5rem",
-	paddingRight: hasPadding ? "1rem" : 0,
-	"&:hover": {
-		color: theme.palette.mode === "dark" ? "#ffffff" : "#000000"
-	}
+		color: theme.palette.strongText,
+	},
 }))

--- a/src/components/styled/StyledLinks.ts
+++ b/src/components/styled/StyledLinks.ts
@@ -1,4 +1,4 @@
-import { styled } from "@mui/material";
+import { styled } from "@mui/material"
 import { Link } from "react-router-dom"
 
 export const LinkIcon = styled(Link, {
@@ -7,31 +7,31 @@ export const LinkIcon = styled(Link, {
 	padding: hasPadding ? "0.5rem 0.5rem 0.5rem 0" : 0,
 	color: theme.palette.text.primary,
 	"&:hover": {
-		backgroundColor: "transparent"
-	}
-}));
+		backgroundColor: "transparent",
+	},
+}))
 
 export const LinkNavText = styled(Link, {
 	shouldForwardProp: (prop) => prop !== "hasPadding",
 })<{ hasPadding?: boolean }>(({ hasPadding, theme }) => ({
 	padding: hasPadding ? "0.5rem" : "0",
-	color: theme.palette.text.primary
-}));
+	color: theme.palette.text.primary,
+}))
 
 export const LinkText = styled(Link, {
 	shouldForwardProp: (prop) => !["hasPadding", "isBold"].includes(prop as string),
-})<{ hasPadding?: boolean, isBold?: boolean }>(({ hasPadding, isBold, theme }) => ({
+})<{ hasPadding?: boolean; isBold?: boolean }>(({ hasPadding, isBold, theme }) => ({
 	padding: hasPadding ? "0.5rem" : "0",
 	fontWeight: isBold ? "bold" : "normal",
 	color: theme.palette.text.primary,
 	"&:hover": {
 		background: "none",
-		color: theme.palette.mode === "dark" ? "#ffffff" : "#000000"
-	}
-}));
+		color: theme.palette.strongText,
+	},
+}))
 
 export const LinkWrapper = styled(Link)(() => ({
 	padding: 0,
 	margin: 0,
-	textDecoration: "none"
-}));
+	textDecoration: "none",
+}))

--- a/src/components/styled/StyledText.ts
+++ b/src/components/styled/StyledText.ts
@@ -1,21 +1,24 @@
-import { styled, Typography } from "@mui/material";
+import { styled, Typography } from "@mui/material"
 
 export const Heading = styled(Typography, {
 	shouldForwardProp: (prop) => prop !== "hasPadding",
 })<{ hasPadding?: boolean }>(({ hasPadding, theme }) => ({
 	fontWeight: "bold",
 	paddingBottom: hasPadding ? "1rem" : "0",
-	color: theme.palette.mode === "dark" ? "#ffffff" : "#000000"
-}));
+	color: theme.palette.strongText,
+}))
 
-export const Subhead = styled(Typography)(({ theme }) => ({
+export const Subhead = styled(Typography, {
+	shouldForwardProp: (prop) => prop !== "hasPaddingBottom",
+})<{ hasPaddingBottom?: boolean }>(({ hasPaddingBottom, theme }) => ({
 	fontWeight: "normal",
 	color: theme.palette.text.secondary,
-	fontSize: "14px"
+	fontSize: "14px",
+	paddingBottom: hasPaddingBottom ? "0.5rem" : 0,
 }))
 
 export const Text = styled(Typography)(() => ({
 	fontWeight: "normal",
 	paddingBottom: "1rem",
-	fontSize: "14px"
+	fontSize: "14px",
 }))

--- a/src/data/projects.data.ts
+++ b/src/data/projects.data.ts
@@ -1,32 +1,32 @@
-import { ProjectHistory } from "../types/projectHistory";
+import { ProjectHistory } from "../types/projectHistory"
 
 export const projects: ProjectHistory[] = [
 	{
 		id: 1,
 		title: "HoopInsights API",
 		url: "https://github.com/chadrakdev/HoopInsightsAPI",
-		tags: ["C#", ".NET"],
-		description: "API integrating with an external API to provide data on teams, players and advanced statistics."
+		description:
+			"API integrating with an external API to provide data on teams, players and advanced statistics.",
 	},
 	{
 		id: 2,
 		title: "Portfolio Website",
 		url: "https://github.com/chadrakdev/dev-portfolio",
-		tags: ["TypeScript", "React"],
-		description: "Minimalist portfolio demonstrating ability to design a responsive, modern user interface and work with TypeScript for type safety and create dynamic web components."
+		description:
+			"Minimalist portfolio demonstrating ability to design a responsive, modern user interface and work with TypeScript for type safety and create dynamic web components.",
 	},
 	{
 		id: 3,
 		title: "Password Generator API",
 		url: "https://github.com/chadrakdev/PasswordGeneratorAPI",
-		tags: ["C#", ".NET", "MVC"],
-		description: "API generating customisable, secure passwords focusing on security, encryption, and the algorithmic side of API development."
+		description:
+			"API generating customisable, secure passwords focusing on security, encryption, and the algorithmic side of API development.",
 	},
 	{
 		id: 4,
 		title: "Record Shop API",
 		url: "https://github.com/chadrakdev/RecordShopAPI",
-		tags: ["Java", "Spring Boot", "SQL"],
-		description: "RESTful API for managing a record store's inventory with in-memory data storage with emphasis on scalability and full CRUD operations."
-	}
-];
+		description:
+			"RESTful API for managing a record store's inventory with in-memory data storage with emphasis on scalability and full CRUD operations.",
+	},
+]

--- a/src/data/work.data.ts
+++ b/src/data/work.data.ts
@@ -1,4 +1,4 @@
-import { WorkHistory } from "../types/workHistory";
+import { WorkHistory } from "../types/workHistory"
 
 export const work: WorkHistory[] = [
 	{
@@ -8,8 +8,18 @@ export const work: WorkHistory[] = [
 		start: "Sep 2021",
 		end: "Jul 2022",
 		isCurrent: false,
-		description: "Developed bespoke, responsive HTML email templates and custom components while ensuring cross-client compatibility and maintaining internal legacy systems.",
-		technologies: ["HTML", "CSS", "ASPX", "C#", "ASP.NET", ".NET Framework", "jQuery", "JavaScript"],
+		description:
+			"Developed bespoke, responsive HTML email templates and custom components while ensuring cross-client compatibility and maintaining internal legacy systems.",
+		technologies: [
+			"HTML",
+			"CSS",
+			"ASPX",
+			"C#",
+			"ASP.NET",
+			".NET Framework",
+			"jQuery",
+			"JavaScript",
+		],
 		responsibilities: [
 			"Built and styled responsive email templates, tailored to marketing and campaign needs.",
 			"Developed reusable email components and debugged rendering issues across major email clients including Outlook, Gmail, and Apple Mail.",
@@ -25,8 +35,9 @@ export const work: WorkHistory[] = [
 		start: "Jul 2022",
 		end: "Sep 2022",
 		isCurrent: false,
-		description: "Maintained legacy applications and contributed to real-time trading systems at a leading financial services firm by developing features across a microservices architecture and frontend React interface, working with Java and Spring Boot.",
-		technologies: [ "Java", "Microservices", "Spring", "React", "TypeScript", "Git" ],
+		description:
+			"Maintained legacy applications and contributed to real-time trading systems at a leading financial services firm by developing features across a microservices architecture and frontend React interface, working with Java and Spring Boot.",
+		technologies: ["Java", "Microservices", "Spring", "React", "TypeScript", "Git"],
 		responsibilities: [
 			"Developed and maintained backend services in a distributed architecture, enhancing support for real-time trade data and operational workflows.",
 			"Extended legacy codebases with clean, testable code to meet stakeholder requirements under tight deadlines.",
@@ -42,8 +53,9 @@ export const work: WorkHistory[] = [
 		start: "Oct 2022",
 		end: "Oct 2023",
 		isCurrent: false,
-		description: "Completed an intensive software engineering program developing full-stack solutions, and applying modern engineering practices to real-world projects in partnership with BAE Digital Intelligence.",
-		technologies:  [ "C#", ".NET", "xUnit", "Moq", "TypeScript", "React", "Jest", "REST API" ],
+		description:
+			"Completed an intensive software engineering program developing full-stack solutions, and applying modern engineering practices to real-world projects in partnership with BAE Digital Intelligence.",
+		technologies: ["C#", ".NET", "xUnit", "Moq", "TypeScript", "React", "Jest", "REST API"],
 		responsibilities: [
 			"Built strong foundations in C#, .NET, TypeScript, and DevOps practices through structured learning and assigned projects.",
 			"Designed and developed RESTful APIs with secure authentication using OAuth and JWT, following SOLID and clean architecture principles.",
@@ -59,7 +71,8 @@ export const work: WorkHistory[] = [
 		start: "Nov 2023",
 		end: "Sep 2025",
 		isCurrent: false,
-		description: "Resolved complex software issues within defined SLOs while developing internal tools, managing integrations, and collaborating with development teams to improve workflows, performance, and system reliability.",
+		description:
+			"Resolved complex software issues within defined SLOs while developing internal tools, managing integrations, and collaborating with development teams to improve workflows, performance, and system reliability.",
 		technologies: ["C#", "ASP.NET", ".NET Framework", "JavaScript", "React", "PowerShell"],
 		responsibilities: [
 			"Developed internal tooling and support applications to streamline workflows and improve efficiency for service desk agents.",
@@ -75,14 +88,25 @@ export const work: WorkHistory[] = [
 		position: "Software Engineer",
 		start: "Oct 2025",
 		isCurrent: true,
-		description: "Developing and maintaining full stack applications and cloud-hosted systems through feature delivery, operational improvements, and structured deployment processes. Working across software engineering, CI/CD, production support, and system reliability.",
-		technologies: ["AWS", "Azure", "Python", "Django", "FastAPI", "C#", ".NET", "React", "TypeScript"],
+		description:
+			"Developing and maintaining full stack applications and cloud-hosted systems through feature delivery, operational improvements, and structured deployment processes. Working across software engineering, CI/CD, production support, and system reliability.",
+		technologies: [
+			"AWS",
+			"Azure",
+			"Python",
+			"Django",
+			"FastAPI",
+			"C#",
+			".NET",
+			"React",
+			"TypeScript",
+		],
 		responsibilities: [
 			"Develop and deploy code changes for feature enhancements, bug fixes, and production incident resolutions across client systems.",
 			"Build and maintain CI/CD pipelines, deployment automation, and release processes to support safe and reliable software delivery.",
 			"Investigate and resolve technical issues escalated from support teams, including root cause analysis and code-level fixes.",
 			"Support infrastructure and operational improvements across cloud-hosted environments using technologies.",
 			"Collaborate with cross-functional teams and stakeholders to deliver technical solutions aligned with business and product requirements.",
-		]
-	}
-];
+		],
+	},
+]

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,12 @@
 import { StrictMode } from "react"
-import { BrowserRouter as Router } from "react-router-dom";
+import { BrowserRouter as Router } from "react-router-dom"
 import { createRoot } from "react-dom/client"
 import App from "./App.tsx"
 
-import "@fontsource/roboto/300.css";
-import "@fontsource/roboto/400.css";
-import "@fontsource/roboto/500.css";
-import "@fontsource/roboto/700.css";
+import "@fontsource/roboto/300.css"
+import "@fontsource/roboto/400.css"
+import "@fontsource/roboto/500.css"
+import "@fontsource/roboto/700.css"
 
 createRoot(document.getElementById("root")!).render(
 	<StrictMode>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,12 +1,36 @@
-import { createTheme } from "@mui/material/styles";
+import { createTheme } from "@mui/material/styles"
 
 declare module "@mui/material/styles" {
 	interface Palette {
-		navBackground?: string;
+		navBackground?: string
+		// Full-contrast color for emphasized text/icons (headings, hovered links) that
+		// deliberately ignores the softer text.primary/secondary tones.
+		strongText: string
+		// Background used when hovering a content block (e.g. project/work list items).
+		surfaceHover: string
+		// Translucent overlay used for the global link hover state in CssBaseline.
+		hoverOverlay: string
 	}
 	interface PaletteOptions {
-		navBackground?: string;
+		navBackground?: string
+		strongText: string
+		surfaceHover: string
+		hoverOverlay: string
 	}
+}
+
+const darkPalette = {
+	navBackground: "#18181bfa",
+	strongText: "#ffffff",
+	surfaceHover: "#1d1d21",
+	hoverOverlay: "#ffffff26",
+}
+
+const lightPalette = {
+	navBackground: "#f4f4f5eb",
+	strongText: "#000000",
+	surfaceHover: "#d8d8db",
+	hoverOverlay: "#00000026",
 }
 
 export const darkTheme = createTheme({
@@ -15,7 +39,7 @@ export const darkTheme = createTheme({
 		background: {
 			default: "#18181b",
 		},
-		navBackground: "#18181bfa",
+		...darkPalette,
 		text: {
 			primary: "#d4d4d8",
 			secondary: "#787884",
@@ -32,14 +56,14 @@ export const darkTheme = createTheme({
 					color: "inherit",
 					transition: "background-color 0.3s ease-in, border-radius 0.3s ease-in",
 					"&:hover": {
-						backgroundColor: "#ffffff26",
-						borderRadius: "0.2rem"
+						backgroundColor: darkPalette.hoverOverlay,
+						borderRadius: "0.2rem",
 					},
-				}
+				},
 			},
-		}
+		},
 	},
-});
+})
 
 export const lightTheme = createTheme({
 	palette: {
@@ -47,7 +71,7 @@ export const lightTheme = createTheme({
 		background: {
 			default: "#f4f4f5",
 		},
-		navBackground: "#f4f4f5eb",
+		...lightPalette,
 		text: {
 			primary: "#18181b",
 			secondary: "#373743",
@@ -64,11 +88,11 @@ export const lightTheme = createTheme({
 					color: "inherit",
 					transition: "background-color 0.3s ease-in, border-radius 0.3s ease-in",
 					"&:hover": {
-						backgroundColor: "#00000026",
-						borderRadius: "0.2rem"
+						backgroundColor: lightPalette.hoverOverlay,
+						borderRadius: "0.2rem",
 					},
-				}
+				},
 			},
 		},
 	},
-});
+})

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,9 @@
+import { ReactNode } from "react"
+
+export interface WithChildren {
+	children: ReactNode
+}
+
+export interface DisplayCountProps {
+	displayCount?: number
+}

--- a/src/types/projectHistory.ts
+++ b/src/types/projectHistory.ts
@@ -1,7 +1,6 @@
 export interface ProjectHistory {
-	id: number,
-    title: string,
-    url: string,
-	tags: string[],
+	id: number
+	title: string
+	url: string
 	description: string
 }

--- a/src/types/workHistory.ts
+++ b/src/types/workHistory.ts
@@ -1,14 +1,14 @@
 export interface BaseWorkHistory {
-	id: number;
-	company: string;
-	position: string;
-	start: string;
-	isCurrent: boolean;
-	description: string;
-	technologies: string[];
-	responsibilities: string[];
-  }
-  
-export type WorkHistory = 
+	id: number
+	company: string
+	position: string
+	start: string
+	isCurrent: boolean
+	description: string
+	technologies: string[]
+	responsibilities: string[]
+}
+
+export type WorkHistory =
 	| (BaseWorkHistory & { isCurrent: true; end?: never })
-	| (BaseWorkHistory & { isCurrent: false; end: string });
+	| (BaseWorkHistory & { isCurrent: false; end: string })

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,26 +1,26 @@
 {
-  "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
+	"compilerOptions": {
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+		"target": "ES2020",
+		"useDefineForClassFields": true,
+		"lib": ["ES2020", "DOM", "DOM.Iterable"],
+		"module": "ESNext",
+		"skipLibCheck": true,
 
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-    "jsx": "react-jsx",
+		/* Bundler mode */
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"isolatedModules": true,
+		"moduleDetection": "force",
+		"noEmit": true,
+		"jsx": "react-jsx",
 
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
-  },
-  "include": ["src"]
+		/* Linting */
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedSideEffectImports": true
+	},
+	"include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ]
+	"files": [],
+	"references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,24 +1,24 @@
 {
-  "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2022",
-    "lib": ["ES2023"],
-    "module": "ESNext",
-    "skipLibCheck": true,
+	"compilerOptions": {
+		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+		"target": "ES2022",
+		"lib": ["ES2023"],
+		"module": "ESNext",
+		"skipLibCheck": true,
 
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "noEmit": true,
+		/* Bundler mode */
+		"moduleResolution": "bundler",
+		"allowImportingTsExtensions": true,
+		"isolatedModules": true,
+		"moduleDetection": "force",
+		"noEmit": true,
 
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
-  },
-  "include": ["vite.config.ts"]
+		/* Linting */
+		"strict": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUncheckedSideEffectImports": true
+	},
+	"include": ["vite.config.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,11 +630,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@pkgr/core@^0.1.0":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
-  integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
-
 "@popperjs/core@^2.11.8":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
@@ -1425,14 +1420,6 @@ eslint-config-prettier@^9.1.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz#31af3d94578645966c082fcb71a5846d3c94867f"
   integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
 
-eslint-plugin-prettier@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz#d1c8f972d8f60e414c25465c163d16f209411f95"
-  integrity sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
-    synckit "^0.9.1"
-
 eslint-plugin-react-hooks@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0.tgz#3d34e37d5770866c34b87d5b499f5f0b53bf0854"
@@ -1562,11 +1549,6 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-diff@^1.1.2:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
-  integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
 
 fast-glob@^3.3.2:
   version "3.3.2"
@@ -2319,13 +2301,6 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
-
 prettier@^3.4.2:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.4.2.tgz#a5ce1fb522a588bf2b78ca44c6e6fe5aa5a2b13f"
@@ -2701,14 +2676,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-synckit@^0.9.1:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.9.2.tgz#a3a935eca7922d48b9e7d6c61822ee6c3ae4ec62"
-  integrity sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==
-  dependencies:
-    "@pkgr/core" "^0.1.0"
-    tslib "^2.6.2"
-
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
@@ -2720,11 +2687,6 @@ ts-api-utils@^1.3.0:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.4.3.tgz#bfc2215fe6528fecab2b0fba570a2e8a4263b064"
   integrity sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==
-
-tslib@^2.6.2:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 turbo-stream@2.4.0:
   version "2.4.0"


### PR DESCRIPTION
## Summary

Codebase remediation driven by Claude Codem focusing on ESLint/Prettier configuration hygiene,
modern TypeScript conventions, MUI styling consistency, and dead code
cleanup. 

Primary constraint was to avoid major visual changes, other than removing redundant nested fade-in animations.

## Tooling

- **ESLint**: `dist/` is now excluded (it was previously being linted as
  source, producing 100+ spurious errors from the minified bundle).
  Registered `eslint-plugin-react-hooks` (`rules-of-hooks` +
  `exhaustive-deps`), which caught a real missing-dependency bug in
  `App.tsx`. Added `react: { version: "detect" }` to silence a config
  warning.
- **Prettier**: added `.prettierrc` / `.prettierignore` and wired
  `eslint-config-prettier` in as the final ESLint config entry so
  formatting rules no longer conflict between the two tools. Removed the
  unused `eslint-plugin-prettier` dependency. Added `format` /
  `format:check` npm scripts. Ran Prettier once across the repo
  (formatting-only diff — verified no data/content changed).

## TypeScript

- Replaced the `React.FC<Props>` pattern with direct prop typing
  (`({ prop }: Props) => ...`) across all components — it was also being
  used inconsistently (some files relied on an implicit global `React`
  namespace instead of importing it).
- Added `src/types/common.ts` with shared `WithChildren` and
  `DisplayCountProps` types, replacing duplicated `LayoutProps` /
  `WorkProps` / `ProjectsProps` interfaces.
- `Work` and `Projects` now use the same `displayCount == null ? all : slice(...)`
  idiom instead of two different patterns for the same "show everything
  by default" behavior.

## MUI styling

- Extended the `theme.ts` palette with `strongText`, `surfaceHover`, and
  `hoverOverlay` tokens, replacing `theme.palette.mode === "dark" ? "#fff" : "#000"`-style
  ternaries duplicated across `StyledText`, `StyledIcons`, `StyledLinks`,
  and `StyledContainers`. Same resulting colors, single source of truth.
- Folded the one-off `sx={{ paddingBottom: "0.5rem" }}` in `Work.tsx` into
  a `hasPaddingBottom` variant on the `Subhead` styled component, matching
  the rest of the codebase's styled-component API.

## Dead code / duplication

- `AppLayout` / `PageLayout` now consume the previously-unused
  `AppContainer` / `PageContainer` exports from `StyledContainers.ts`
  instead of re-declaring identical local styled containers.
- Removed the unused `Twitter` icon export.
- Removed the unused `tags` field from `ProjectHistory` (type + data) —
  it was never rendered and is confirmed not needed.

## Architecture

- `Work`, `Projects`, and `Contact` no longer self-wrap in
  `AnimatedContainer`, making them plain, reusable section components.
  `Home.tsx` now applies a single `AnimatedContainer` around its whole
  composed tree (previously each embedded section re-triggered its own
  fade-in). `App.tsx` wraps the standalone `/work`, `/projects`,
  `/contact` routes in `AnimatedContainer` so direct navigation still
  animates as before.
- Moved `App.tsx`'s route-title logic (`parsePath`) out of the component
  and fixed the `useEffect` it was implicitly missing as a dependency of.

## Verification
Project builds successfully and manual check was performed, comparing current Production application against the local preview.