### PR TITLE
DOCS: Add technical/operational documentation

### DIFF
--- a/docs/operational/OPERATIONS.md
+++ b/docs/operational/OPERATIONS.md
@@ -218,6 +218,3 @@ have breaking changes that show up as type errors or runtime warnings.
   specifically to disable ESLint's own stylistic rules in favor of
   Prettier. If a new ESLint plugin gets added later, make sure it's
   added *before* `eslintConfigPrettier` in the config array, not after.
-
-- **Something else entirely.**
-  <!-- TODO: fill in as new issues come up — that's the point of this section -->

--- a/docs/operational/OPERATIONS.md
+++ b/docs/operational/OPERATIONS.md
@@ -1,0 +1,223 @@
+# Operations
+
+How to run, build, deploy, and maintain `dev-portfolio`. Pairs with
+[`../technical/ARCHITECTURE.md`](../technical/ARCHITECTURE.md), which
+covers *what* the codebase is; this covers *how to work with it*.
+
+## 1. Local setup
+
+**Prerequisites:**
+- Node.js 22 (matches what CI uses — see [CI/CD](#3-cicd)).
+  <!-- TODO: no .nvmrc/.node-version is committed; if you add one, update this line -->
+- Yarn (the repo has a committed `yarn.lock`; use Yarn for installs so
+  the lockfile stays authoritative).
+
+**Steps:**
+
+```bash
+git clone git@github.com:chadrakdev/dev-portfolio.git
+cd dev-portfolio
+yarn install
+yarn dev
+```
+
+`yarn dev` starts the Vite dev server (default `http://localhost:5173`)
+with hot module reload.
+
+**Environment variables:** none. There's no `.env` file, no
+`import.meta.env.*` usage anywhere in `src/`, and nothing in `.gitignore`
+suggests one is expected. The only environment-sensitive values
+(Netlify auth token, site ID) are CI/deploy secrets, not something you
+need locally — see [Build & deploy](#2-build--deploy).
+
+**Other scripts you'll use locally:**
+
+```bash
+yarn lint            # ESLint (flat config, eslint.config.js)
+yarn tsc --noEmit     # Type-check without emitting (what CI runs)
+yarn format:check     # Prettier — check formatting without changing files
+yarn format           # Prettier — reformat in place
+yarn build            # Full production build (tsc -b && vite build)
+yarn preview          # Serve the built dist/ locally, for a last check before deploying
+```
+
+## 2. Build & deploy
+
+**Build:**
+
+```bash
+yarn build
+```
+
+This runs `tsc -b && vite build` (see `package.json` → `scripts.build`).
+`tsc -b` type-checks the whole project (using project references across
+`tsconfig.app.json` / `tsconfig.node.json`) and fails the build on type
+errors before Vite ever bundles anything. Output goes to `dist/`
+(gitignored).
+
+**Deploy:** fully automated via GitHub Actions — there is no manual
+deploy step.
+
+- Every push to `main` triggers `.github/workflows/deploy.yml`, which
+  builds the app, then deploys `dist/` to **Netlify** via
+  `npx netlify-cli deploy --prod --dir=dist`.
+- Netlify auth is via two GitHub repo-level values used as env vars in
+  that step: `NETLIFY_AUTH_TOKEN` (secret) and `NETLIFY_PROJECT_ID`
+  (variable). <!-- TODO: confirm these are still the correct secret/variable names if deploy ever starts failing on auth -->
+- The site is live at both `chadrakdev.netlify.app` and the custom
+  domain `chadrak.dev` (see the smoke-test step below — both URLs are
+  checked).
+- **SPA routing on Netlify** depends on `public/_redirects`
+  (`/* /index.html 200`). If routes other than `/` start 404ing on
+  Netlify after a deploy, check this file wasn't removed or that Netlify
+  is actually picking it up from `dist/`.
+
+There is no separate staging environment — `main` is production.
+
+## 3. CI/CD
+
+Two workflows, both in `.github/workflows/`:
+
+### `pr-checks.yml` — runs on every PR, and on every push to `main`
+
+Jobs run in sequence (`lint` → `build` → `test`):
+
+1. **Lint** — `yarn lint` (ESLint) and `yarn tsc --noEmit` (type check).
+2. **Build** — `npm run build` (full production build; catches anything
+   lint/type-check didn't).
+3. **Test** — currently a placeholder: `echo "Tests will run here"`.
+   No actual tests run yet.
+
+**What "green" actually verifies today:** the code lints clean, type
+checks clean, and produces a working production bundle. It does **not**
+verify runtime behavior — there's no automated check that the app
+actually renders correctly, since the test job is a no-op.
+
+Has `concurrency` configured to cancel superseded runs on the same
+branch/ref, so pushing again quickly cancels the older run.
+
+### `deploy.yml` — runs on push to `main` only
+
+Jobs run in sequence (`build` → `test` → `deploy` → `smoke-test`):
+
+1. **Build** — `npm run build`, uploads `dist/` as a workflow artifact.
+2. **Test** — same placeholder as above.
+3. **Deploy** — downloads the `dist/` artifact, deploys it to Netlify.
+4. **Smoke test** — after deploy, `curl`s both
+   `https://chadrakdev.netlify.app/` and `https://chadrak.dev/` and
+   fails the workflow if either doesn't return HTTP 200.
+
+So a successful `deploy.yml` run means: it built, it deployed, and both
+production URLs are actually reachable afterward — a real (if shallow)
+end-to-end check.
+
+**Note:** both workflows install dependencies with
+`yarn install --frozen-lockfile` but then invoke build/lint via a mix of
+`npm run build` and `yarn lint`. This works (both just run the
+`package.json` scripts) but is inconsistent.
+<!-- TODO: pick one package manager invocation style and use it everywhere -->
+
+## 4. Common tasks
+
+### Add or update a job / project (the most common content change)
+
+- Jobs: edit `src/data/work.data.ts`. Each entry is a `WorkHistory`
+  object — note that `end` is required unless `isCurrent: true` (see
+  [ARCHITECTURE.md § design decisions](../technical/ARCHITECTURE.md#5-design-decisions--trade-offs)
+  for why). When starting a new current role, set the previous one's
+  `isCurrent: false` and give it an `end` date.
+- Projects: edit `src/data/projects.data.ts`. Each entry is a
+  `ProjectHistory` object (`id`, `title`, `url`, `description`).
+- Both arrays are rendered newest-last / newest-first depending on the
+  component (`Work.tsx` reverses the array before rendering — check
+  there if ordering looks wrong after an edit).
+- Commit, push, open a PR (or push straight to `main` if working solo
+  without review) — CI + deploy handle the rest.
+
+### Add a new page/route
+
+1. Create the component under `src/components/pages/`.
+2. Add a `<Route>` for it in `src/App.tsx`, wrapped in
+   `<AnimatedContainer>` to match the existing routes' fade-in behavior.
+3. Add a nav link in `src/components/navigation/NavBar.tsx` if it should
+   be reachable from the nav bar.
+4. Add the route's title to the `parsePath` switch in `App.tsx` so the
+   document title updates correctly.
+
+### Add a new reusable styled component
+
+Put it in the relevant file under `src/components/styled/`
+(`StyledText.ts`, `StyledContainers.ts`, `StyledLinks.ts`,
+`StyledIcons.ts`) following the existing pattern: `styled(X, {
+shouldForwardProp: ... })<{ someBooleanProp?: boolean }>(({ someBooleanProp, theme }) => ({ ... }))`.
+Reuse theme palette tokens (`theme.palette.strongText`,
+`theme.palette.surfaceHover`, etc.) instead of hardcoding
+mode-dependent hex colors — see `theme.ts`.
+
+### Add a dependency
+
+```bash
+yarn add <package>          # runtime dependency
+yarn add -D <package>       # dev dependency
+```
+
+Commit the updated `package.json` and `yarn.lock` together.
+
+### Update a dependency
+
+```bash
+yarn upgrade <package>              # respects the semver range in package.json
+yarn upgrade <package> --latest     # ignores the range, jumps to latest
+```
+
+After upgrading, run the full check locally before pushing:
+
+```bash
+yarn install && yarn lint && yarn tsc --noEmit && yarn build
+```
+
+Pay particular attention to major version bumps of `react`, `react-dom`,
+`react-router-dom`, and `@mui/*` — these are the packages most likely to
+have breaking changes that show up as type errors or runtime warnings.
+
+### Bump the Node version
+
+1. Update `node-version:` in both `.github/workflows/deploy.yml` and
+   `.github/workflows/pr-checks.yml` (currently `22` in each — there are
+   two separate `setup-node` steps per file, one per job, so check all
+   of them).
+2. If you add a `.nvmrc`/`.node-version` file locally, keep it in sync
+   with the CI value.
+3. Re-run `yarn install` locally under the new Node version and confirm
+   `yarn build` still passes.
+
+## 5. Troubleshooting
+
+- **`yarn build` fails with type errors that `yarn dev` didn't show.**
+  Vite's dev server doesn't type-check on every change the way `tsc -b`
+  does during a full build. Run `yarn tsc --noEmit` directly to get the
+  same check locally without doing a full build.
+
+- **ESLint is reporting errors from `dist/`.** Shouldn't happen —
+  `eslint.config.js` has `{ ignores: ["dist"] }` as its first entry. If
+  this regresses, check that entry is still present and still first (or
+  at least present) in the config array.
+
+- **Routes other than `/` 404 after a Netlify deploy.** Check
+  `public/_redirects` still contains `/* /index.html 200` and is present
+  in the built `dist/` output (Vite copies everything in `public/` as-is
+  into `dist/` — confirm it's not accidentally excluded).
+
+- **Deploy step fails on Netlify auth.** Check the `NETLIFY_AUTH_TOKEN`
+  secret and `NETLIFY_PROJECT_ID` repo variable are still set and valid
+  in the GitHub repo settings — these aren't stored in the repo itself.
+  <!-- TODO: confirm where/how to rotate the Netlify token if it expires -->
+
+- **Prettier and ESLint disagree about formatting.** Shouldn't happen —
+  `eslint-config-prettier` is the last entry in `eslint.config.js`
+  specifically to disable ESLint's own stylistic rules in favor of
+  Prettier. If a new ESLint plugin gets added later, make sure it's
+  added *before* `eslintConfigPrettier` in the config array, not after.
+
+- **Something else entirely.**
+  <!-- TODO: fill in as new issues come up — that's the point of this section -->

--- a/docs/technical/ARCHITECTURE.md
+++ b/docs/technical/ARCHITECTURE.md
@@ -1,0 +1,248 @@
+# Architecture
+
+Technical documentation for the `dev-portfolio` codebase. Written for
+future-me, reading this cold after months away.
+
+## 1. Overview
+
+This is a personal developer portfolio site — a single-page application
+that acts as an online CV. It shows a short bio, work history, a list of
+side projects (linking out to their GitHub repos), and contact links
+(GitHub, LinkedIn, email).
+
+- **Who it's for**: me — it's shown to recruiters/hiring managers/anyone
+  who wants a quick read on my background, and it doubles as a live
+  demonstration of frontend ability (see the "Portfolio Website" entry in
+  `src/data/projects.data.ts`, which literally says this).
+- **Current state**: stable. It's deployed and live at
+  [chadrak.dev](https://chadrak.dev). Content (jobs, projects) gets
+  updated periodically by editing the data files directly — see
+  [Common tasks](../operational/OPERATIONS.md#4-common-tasks).
+- **Scope**: intentionally small — 4 routes, no backend, no database, no
+  auth. Content is hardcoded TypeScript, not fetched from anywhere.
+
+## 2. Tech stack
+
+| Tool | Version | Why |
+| --- | --- | --- |
+| **React** | 19 | UI library. Also the framework I want the site itself to demonstrate proficiency in. |
+| **TypeScript** | ~5.7 | Type safety across components, data, and props — explicitly called out as a goal in the project's own "Portfolio Website" project description. |
+| **Vite** | ^6 | Dev server + build tool. Modern default over CRA (which is deprecated); fast HMR, minimal config. |
+| **React Router (`react-router-dom`)** | ^7 | Client-side routing for the 4 pages (Home, Work, Projects, Contact). Handles both internal routes and, via its built-in absolute-URL detection, the external links (GitHub, LinkedIn, `mailto:`) rendered through the same `<Link>` component. |
+| **MUI (`@mui/material`, `@mui/icons-material`)** | ^6 | Component library + theming system. Used for its `styled()` API, `ThemeProvider`/dark-light theming, `CssBaseline`, and icon set — avoids hand-rolling a design system from scratch. |
+| **Emotion (`@emotion/react`, `@emotion/styled`)** | ^11 | MUI's styling engine under the hood; used directly for the custom `styled()` components in `src/components/styled/`. |
+| **Fontsource (`@fontsource/roboto`)** | ^5 | Self-hosts the Roboto font (MUI's default typeface) instead of pulling from Google Fonts at runtime — avoids an external network dependency. |
+| **ESLint 9 (flat config) + typescript-eslint** | ^9 / ^8 | Linting, including type-aware rules and React-specific rules (`eslint-plugin-react`, `eslint-plugin-react-hooks`). |
+| **Prettier** | ^3 | Formatting, decoupled from ESLint via `eslint-config-prettier` so the two don't fight over style rules. |
+
+No state management library (Redux, Zustand, etc.), no CSS framework
+(Tailwind, etc.), no data-fetching library — none of these are needed at
+this scale. No test runner is currently installed (see
+[Known limitations](#6-known-limitations--things-id-do-differently)).
+
+## 3. Architecture
+
+### Folder layout
+
+```
+src/
+├── App.tsx                  # Root: theme state, routing, document title
+├── main.tsx                 # Entry point: mounts <App> inside <BrowserRouter>
+├── theme.ts                 # MUI dark/light theme definitions + custom palette tokens
+├── vite-env.d.ts            # Vite's ambient type declarations
+│
+├── components/
+│   ├── layouts/
+│   │   ├── AppLayout.tsx    # Outermost width-constrained wrapper
+│   │   └── PageLayout.tsx   # Page-level padding wrapper
+│   ├── navigation/
+│   │   └── NavBar.tsx       # Sticky top nav + theme toggle
+│   ├── footer/
+│   │   └── Footer.tsx       # Copyright line
+│   ├── content/
+│   │   ├── ContentList.tsx      # Generic list wrapper
+│   │   └── ContentListItem.tsx  # Single project card (title/description/link)
+│   ├── pages/
+│   │   ├── Home.tsx         # Composes bio + Work + Projects + Contact
+│   │   ├── Work.tsx         # Work history (full or preview via `displayCount`)
+│   │   ├── Projects.tsx     # Project list (full or preview via `displayCount`)
+│   │   └── Contact.tsx      # Social + email links
+│   └── styled/
+│       ├── StyledContainers.ts  # Layout primitives (ContentSection, PageSection, AnimatedContainer, TagList...)
+│       ├── StyledText.ts        # Typography primitives (Heading, Subhead, Text)
+│       ├── StyledLinks.ts       # react-router Link-based primitives (LinkIcon, LinkText, LinkNavText, LinkWrapper)
+│       ├── StyledIcons.ts       # Icon wrappers (LightMode, DarkMode, GitHub, LinkedIn)
+│       └── Animations.ts        # fadeInAnimation keyframes
+│
+├── data/
+│   ├── work.data.ts         # Work history content (array of WorkHistory)
+│   └── projects.data.ts     # Project list content (array of ProjectHistory)
+│
+└── types/
+    ├── common.ts             # Shared prop-shape types (WithChildren, DisplayCountProps)
+    ├── workHistory.ts        # WorkHistory type (discriminated union, see below)
+    └── projectHistory.ts     # ProjectHistory type
+```
+
+### Key modules
+
+- **`App.tsx`** is the composition root. It owns the one piece of
+  meaningful app state (`isDarkMode`), wires up `ThemeProvider` +
+  `CssBaseline`, defines the `<Routes>` table, and sets `document.title`
+  per route via a `useEffect` keyed on `location.pathname`.
+- **`theme.ts`** defines two MUI themes (`darkTheme`/`lightTheme`) built
+  from `createTheme`. The MUI `Palette` type is augmented (via TS module
+  augmentation) with three custom tokens — `navBackground`, `strongText`,
+  `surfaceHover`, `hoverOverlay` — so mode-dependent colors are defined
+  once here instead of being re-derived with `theme.palette.mode ===
+  "dark" ? ... : ...` ternaries scattered through component files.
+- **`components/styled/`** is a small internal design system: MUI
+  `styled()` wrappers around `Typography`, `Box`, `Link` (from
+  react-router), and icon components, each taking boolean "modifier"
+  props (`hasPadding`, `hasBorder`, `isBold`, etc.) instead of using the
+  `sx` prop inline. Every page composes UI out of these primitives rather
+  than styling ad hoc.
+- **`data/*.ts`** is the actual content of the site — not fetched, just
+  imported as TypeScript modules. Updating the site's content means
+  editing these files and redeploying.
+
+### Data flow
+
+There's no client-server data flow — it's all static, in-memory,
+build-time content:
+
+```mermaid
+flowchart TD
+    subgraph Entry
+        main[main.tsx] --> Router[BrowserRouter]
+        Router --> App[App.tsx]
+    end
+
+    App -->|"ThemeProvider(darkTheme | lightTheme)"| Theme[theme.ts]
+    App --> AppLayout
+    AppLayout --> NavBar
+    AppLayout --> PageLayout
+    AppLayout --> Footer
+
+    PageLayout --> Routes{Routes}
+    Routes -->|"/"| Home
+    Routes -->|"/work"| Work
+    Routes -->|"/projects"| Projects
+    Routes -->|"/contact"| Contact
+
+    Home --> Work
+    Home --> Projects
+    Home --> Contact
+
+    Work -->|reads| WorkData[data/work.data.ts]
+    Projects -->|reads| ProjectsData[data/projects.data.ts]
+    Projects --> ContentListItem
+```
+
+### State management
+
+- **Theme (dark/light)**: a single `useState<boolean>` in `App.tsx`,
+  passed down one level as a prop (`isDarkMode`, `onToggleTheme`) to
+  `NavBar`. Not persisted — see [limitations](#6-known-limitations--things-id-do-differently).
+- **Everything else is derived, not stateful**: `location.pathname` comes
+  from `react-router-dom`'s `useLocation`; page content comes straight
+  from the imported data arrays; there's no global store, no context
+  beyond what MUI's `ThemeProvider` provides internally.
+
+## 4. Key features
+
+| Feature (user-facing) | Where it lives |
+| --- | --- |
+| Light/dark theme toggle (nav bar icon) | `App.tsx` (state), `theme.ts` (palettes), `components/navigation/NavBar.tsx` (button) |
+| Sticky, translucent nav bar | `components/navigation/NavBar.tsx`, `NavContainer` in `StyledContainers.ts` |
+| Home page: bio + preview of most recent job + 2 project previews + contact block | `components/pages/Home.tsx` (composes `Work`, `Projects`, `Contact` with `displayCount` props) |
+| Full work history page (all roles, tech tags, responsibilities) | `components/pages/Work.tsx` + `data/work.data.ts` + `types/workHistory.ts` |
+| Full projects page (linking out to GitHub repos) | `components/pages/Projects.tsx` + `data/projects.data.ts` + `components/content/ContentListItem.tsx` |
+| Contact page (GitHub, LinkedIn, email) | `components/pages/Contact.tsx` |
+| Per-page fade-in animation on navigation | `AnimatedContainer` + `fadeInAnimation` in `components/styled/`, applied per-route in `App.tsx` and once around the whole tree in `Home.tsx` |
+| Per-route document title (`Work \| Chadrak H`, etc.) | `parsePath` + `useEffect` in `App.tsx` |
+| Responsive layout (narrower max-width on small screens) | `AppContainer` in `StyledContainers.ts` (`theme.breakpoints.down("sm")`) |
+
+## 5. Design decisions & trade-offs
+
+- **No backend, no CMS.** Content is hardcoded TypeScript data files.
+  Deliberate — this site changes maybe a few times a year (new job, new
+  project), so a CMS or API would be pure overhead. Trade-off: updating
+  content means a code change + redeploy, not a form submission.
+- **No global state library.** The only real app state is one boolean
+  (dark mode). Prop-drilling one level and letting MUI's `ThemeProvider`
+  handle the rest via context is simpler than introducing Redux/Zustand
+  for a single flag.
+- **`styled()` over the `sx` prop.** Nearly every visual primitive
+  (`Heading`, `Text`, `ContentSection`, `LinkText`, etc.) is a named,
+  reusable `styled()` component with boolean modifier props, rather than
+  inline `sx={{ ... }}` on MUI primitives directly. This keeps the visual
+  language consistent and centralizes styling decisions, at the cost of
+  an extra layer of indirection (you have to go look at
+  `components/styled/` to see what a given prop does).
+- **`Work` / `Projects` double as both full pages and embeddable preview
+  sections.** Both accept an optional `displayCount` prop: omitted, they
+  render everything (the standalone `/work` and `/projects` routes);
+  passed a number, they render a truncated preview (used by `Home.tsx`).
+  This avoids maintaining two separate components/layouts for "full" vs
+  "preview" views, at the cost of these components carrying two
+  responsibilities at once — a layout change to one view can
+  inadvertently affect the other.
+- **`WorkHistory` is a discriminated union**, not a single interface with
+  optional fields:
+  ```ts
+  export type WorkHistory =
+      | (BaseWorkHistory & { isCurrent: true; end?: never })
+      | (BaseWorkHistory & { isCurrent: false; end: string })
+  ```
+  This makes it a compile-time error to add a past role without an `end`
+  date, or a current role with one. Slightly more ceremony than a plain
+  `end?: string`, but it encodes an actual invariant.
+- **Custom MUI palette tokens (`strongText`, `surfaceHover`,
+  `hoverOverlay`, `navBackground`)** were added via TypeScript module
+  augmentation in `theme.ts` specifically to kill repeated
+  `theme.palette.mode === "dark" ? "#fff" : "#000"` ternaries that used
+  to be duplicated across multiple styled-component files. If you find
+  yourself writing another one of those ternaries, add a token instead.
+- **Netlify SPA fallback.** `public/_redirects` contains `/* /index.html
+  200`. Without it, refreshing on `/work` (or any route other than `/`)
+  would 404 on Netlify, because there's no server-side router — only
+  `index.html` + client-side `react-router-dom`.
+- **No tests, on purpose (for now).** Both CI workflows have a literal
+  `echo "Tests will run here"` placeholder test job. Acceptable at this
+  size (mostly static content), but flagged explicitly rather than
+  silently skipped — see limitations below.
+
+## 6. Known limitations / things I'd do differently
+
+- **No test suite.** If this grows any real interactivity (a form,
+  fetched data, more complex conditional rendering), add
+  [Vitest](https://vitest.dev/) + React Testing Library and wire it into
+  the existing CI "Test" job placeholders in both workflow files.
+- **Theme preference isn't persisted.** Dark mode always resets on
+  reload (`useState(true)` in `App.tsx`); it doesn't read/write
+  `localStorage` or respect `prefers-color-scheme`. Known simplification,
+  not a bug.
+- **No 404 / catch-all route.** `App.tsx`'s `<Routes>` has no wildcard
+  route — navigating to an undefined path (e.g. `/foo`) renders an empty
+  `PageLayout` with nav/footer but no page content, instead of a proper
+  not-found page.
+- **Mixed package manager usage in CI.** Both workflows install
+  dependencies with `yarn install --frozen-lockfile` but then run builds
+  via `npm run build` (and lint via `yarn lint`). Works today because
+  both just execute the scripts in `package.json`, but it's inconsistent
+  and worth picking one tool.
+  <!-- TODO: confirm whether this is intentional or just drift -->
+- **`eslint-plugin-react-refresh` is an unused dependency.** It's listed
+  in `package.json` devDependencies but never registered in
+  `eslint.config.js`. Either wire it in (it's meant to catch
+  Fast-Refresh-incompatible exports) or remove it.
+  <!-- TODO: confirm intent, then fix -->
+- **No `.nvmrc` / `.node-version` file.** CI pins Node 22
+  (`.github/workflows/*.yml`), but nothing enforces that locally — it's
+  easy to end up developing against a different Node version than CI
+  uses without noticing.
+- **Content updates require a code change.** By design (see trade-offs
+  above), but worth remembering: adding a job or project means editing
+  `src/data/*.ts` and going through a full commit → PR → CI → deploy
+  cycle, not a quick edit somewhere.


### PR DESCRIPTION
## Summary
Add `ARCHITECTURE.md` and `OPERATIONS.md`

Adds baseline documentation so the project can be picked back up after a break without re-learning the context, the scope of the two new files are as follows:
- `ARCHITECTURE.md` — what the app does, tech stack, structure, key design decisions, known limitations
- `OPERATIONS.md` — local setup, build/deploy, CI/CD overview, common tasks, troubleshooting

No code changes involved.